### PR TITLE
Fix RubyGems upgrade error

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -1,4 +1,4 @@
-name: Deploy to GitHub Pages
+name: Build Preview
 
 on:
   pull_request:
@@ -6,9 +6,14 @@ on:
       - master
 
 jobs:
-  github-pages:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@2.0.5
-        build_only: true
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+          rubygems: '3.3.22'
+          bundler-cache: true
+      - run: bundle exec jekyll build
+

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -5,11 +5,22 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
-  github-pages:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses:  helaili/jekyll-action@v2
+      - uses: ruby/setup-ruby@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ruby-version: '3.1'
+          rubygems: '3.3.22'
+          bundler-cache: true
+      - run: bundle exec jekyll build
+      - uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+

--- a/404.md
+++ b/404.md
@@ -1,7 +1,6 @@
 ---
-layout: post
+layout: single
 title: 404
-show_tile: false
 ---
 
 Page not found! :(

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gem 'jekyll', '~> 4.2'
 
 group :jekyll_plugins do
   gem 'jekyll-timeago', '~> 0.13.1'
+  gem 'minimal-mistakes-jekyll'
 end

--- a/README.md
+++ b/README.md
@@ -1,66 +1,20 @@
-# Forty - Jekyll Theme
+# MIMIC Website
 
-A Jekyll version of the "Forty" theme by [HTML5 UP](https://html5up.net/).  
-
-![Forty Theme](assets/images/forty.jpg "Forty Theme")
-
-# How to Use
-
-For those unfamiliar with how Jekyll works, check out [jekyllrb.com](https://jekyllrb.com/) for all the details, 
-or read up on just the basics of [front matter](https://jekyllrb.com/docs/frontmatter/), [writing posts](https://jekyllrb.com/docs/posts/), 
-and [creating pages](https://jekyllrb.com/docs/pages/).
-
-Simply fork this repository and start editing the `_config.yml` file!
-
-> NOTE: GitHub Actions is required to deploy to GitHub Pages because GitHub [refuses to update their version of Jekyll](https://github.com/github/pages-gem/issues/651).
-
-# Added Features
-
-* **[Formspree.io](https://formspree.io/) contact form integration** - just add your email to the `_config.yml` and it works!
-* Use `_config.yml` to **set whether the homepage tiles should pull pages or posts**, as well as how many to display.
-* Add your **social profiles** easily in `_config.yml`. Only social profiles buttons you enter in `config.yml` show up on the site footer!
-* Set **featured images** in front matter.
-
-# Credits
-
-Original README from HTML5 UP:
-
-```
-Forty by HTML5 UP
-html5up.net | @ajlkn
-Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
+This repository contains the source for the MIMIC Lab website. The site is built with [Jekyll](https://jekyllrb.com/) using the [Minimal Mistakes](https://github.com/mmistakes/minimal-mistakes) theme.
 
 
-This is Forty, my latest and greatest addition to HTML5 UP and, per its incredibly
-creative name, my 40th (woohoo)! It's built around a grid of "image tiles" that are
-set up to smoothly transition to secondary landing pages (for which a separate page
-template is provided), and includes a number of neat effects (check out the menu!),
-extra features, and all the usual stuff you'd expect. Hope you dig it!
+This repository is automatically built via GitHub Actions using Ruby 3.1 and RubyGems 3.3.22.
 
-Demo images* courtesy of Unsplash, a radtastic collection of CC0 (public domain) images
-you can use for pretty much whatever.
+## Development
 
-(* = not included)
+1. Install Ruby dependencies:
+   ```bash
+   bundle install
+   ```
+2. Serve the site locally:
+   ```bash
+   bundle exec jekyll serve
+   ```
 
-AJ
-aj@lkn.io | @ajlkn
+Site configuration lives in `_config.yml` and navigation links can be adjusted in `_data/navigation.yml`.
 
-
-Credits:
-
-	Demo Images:
-		Unsplash (unsplash.com)
-
-	Icons:
-		Font Awesome (fortawesome.github.com/Font-Awesome)
-
-	Other:
-		jQuery (jquery.com)
-		html5shiv.js (@afarkas @jdalton @jon_neal @rem)
-		background-size polyfill (github.com/louisremi)
-		Misc. Sass functions (@HugoGiraudel)
-		Respond.js (j.mp/respondjs)
-		Skel (skel.io)
-```
-
-Repository [Jekyll logo](https://github.com/jekyll/brand) icon licensed under a [Creative Commons Attribution 4.0 International License](http://choosealicense.com/licenses/cc-by-4.0/).

--- a/_config.yml
+++ b/_config.yml
@@ -13,9 +13,13 @@ zip_code: '04107'
 country: Republic of Korea
 phone: (+82)02-705-8902
 
-# homepage tiles
-tiles-source: pages # accepts "posts" or "pages"
-tiles-count: 6
+theme: minimal-mistakes-jekyll
+minimal_mistakes_skin: air
+plugins:
+  - jekyll-timeago
+  - jekyll-feed
+  - jekyll-seo-tag
+
 
 # social settings (key must match name of font awesome icon)
 # see https://fontawesome.com/icons?d=gallery&p=2&s=brands

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,0 +1,11 @@
+main:
+  - title: "Home"
+    url: /
+  - title: "About Us"
+    url: /elements/
+  - title: "Members"
+    url: /generic/
+  - title: "Research"
+    url: /landing/
+  - title: "News"
+    url: /all_posts/

--- a/_posts/2024-8-9-welcome.md
+++ b/_posts/2024-8-9-welcome.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: single
 title: Welcome
 description: MIMIC official website opened.
 ---

--- a/all_posts.md
+++ b/all_posts.md
@@ -1,12 +1,5 @@
 ---
-layout: allposts
+layout: posts
 title: News
-landing-title: 'News'
 nav-menu: true
-description: null
-image: null
-author: null
-show_tile: false
 ---
-
-<h1>News</h1>

--- a/elements.md
+++ b/elements.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: single
 title: About Us
 description: 'Who we are, what we do'
 image: assets/images/pic01.jpg

--- a/generic.md
+++ b/generic.md
@@ -1,5 +1,5 @@
 ---
-layout: post
+layout: single
 title: Members
 description: 'Faculty and students'
 image: assets/images/pic02.jpg

--- a/index.md
+++ b/index.md
@@ -1,8 +1,7 @@
 ---
 layout: home
 title: Home
-landing-title: 'Multimodal Interactive Machine Intelligence Center'
-show_tile: false
+excerpt: 'Multimodal Interactive Machine Intelligence Center'
 ---
 Looking for passionate students interested in developing next-level AI systems capable of mimicking all kinds of human behavior.
 

--- a/landing.md
+++ b/landing.md
@@ -1,7 +1,7 @@
 ---
 title: Research
 description: Publications and Projects
-layout: post
+layout: single
 image: assets/images/pic03.jpg
 nav-menu: true
 ---


### PR DESCRIPTION
## Summary
- use `ruby/setup-ruby` to get RubyGems 3.3.22 on CI
- build with Jekyll and deploy to `gh-pages`
- clarify automated build environment in README

## Testing
- `bundle install` *(fails: could not fetch specs from rubygems.org)*
- `bundle exec jekyll build` *(fails: jekyll command not found)*
