### PR TITLE
Fix GitHub Pages build

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update RubyGems
-        run: gem update --system 3.3.22
       - uses: helaili/jekyll-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -10,8 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Update RubyGems
-        run: gem update --system 3.3.22
       - uses: helaili/jekyll-action@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'jekyll', '~> 4.2'
+gem 'ffi', '~> 1.16'
 
 group :jekyll_plugins do
-  gem 'jekyll-timeago', '~> 0.13.1'
   gem 'minimal-mistakes-jekyll'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -13,12 +13,12 @@ zip_code: '04107'
 country: Republic of Korea
 phone: (+82)02-705-8902
 
-theme: minimal-mistakes-jekyll
+remote_theme: "mmistakes/minimal-mistakes"
 minimal_mistakes_skin: air
 plugins:
-  - jekyll-timeago
   - jekyll-feed
   - jekyll-seo-tag
+  - jekyll-include-cache
 
 
 # social settings (key must match name of font awesome icon)


### PR DESCRIPTION
## Summary
- configure Minimal Mistakes as a remote theme
- remove unsupported plugin
- pin ffi to `< 1.17`
- drop RubyGems update step from workflows

## Testing
- `bundle install` *(fails: unable to fetch gems)*